### PR TITLE
referenced docker image correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Here are some example snippets to help you get started creating a container.
 version: "2.1"
 services:
   webtop:
-    image: ghcr.io/linuxserver/webtop
+    image: linuxserver/webtop
     container_name: webtop
     privileged: true #optional
     environment:
@@ -139,7 +139,7 @@ docker run -d \
   -v /var/run/docker.sock:/var/run/docker.sock `#optional` \
   --shm-size="1gb" `#optional` \
   --restart unless-stopped \
-  ghcr.io/linuxserver/webtop
+  linuxserver/webtop
 ```
 
 ## Parameters


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Running either the docker-compose or the rocker run the referenced docker image cannot be found 
changing it to the correct it seems to be working 

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

docker run -d \
  --name=webtop \
  --privileged `#optional` \
  -e PUID=1000 \
  -e PGID=1000 \
  -e TZ=Europe/London \
  -e SUBFOLDER=/ `#optional` \
  -p 3000:3000 \
  -v /path/to/data:/config \
  -v /var/run/docker.sock:/var/run/docker.sock `#optional` \
  --shm-size="1gb" `#optional` \
  --restart unless-stopped \
  ghcr.io/linuxserver/webtop
<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-webtop/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Running either the docker-compose or the rocker run the referenced docker image cannot be found 
changing it to the correct it seems to be working 

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
reading the readme is not providing the correct information to use this tool 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local development environment 
```shell
╰──$ docker run -d \
  --name=webtop \
  --privileged `#optional` \
  -e PUID=1000 \
  -e PGID=1000 \
  -e TZ=Europe/London \
  -p 3000:3000 \
  -v /path/to/data:/config \
  -v /var/run/docker.sock:/var/run/docker.sock `#optional` \
  --shm-size="1gb" `#optional` \
  --restart unless-stopped \
  ghcr.io/linuxserver/webtop:ubuntu-mate-version-e11b6f20
Unable to find image 'ghcr.io/linuxserver/webtop:ubuntu-mate-version-e11b6f20' locally
docker: Error response from daemon: Head "https://ghcr.io/v2/linuxserver/webtop/manifests/ubuntu-mate-version-e11b6f20": denied: denied.
See 'docker run --help'.      
```
After changing the referenced docker image to `/linuxserver/webtop:ubuntu-mate-version-e11b6f20` it has work


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
