### PR TITLE
rebase kde ubuntu to jammy as focal is not functional without priv mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-rdesktop-web:focal
+FROM ghcr.io/linuxserver/baseimage-rdesktop-web:jammy
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-rdesktop-web:arm64v8-focal
+FROM ghcr.io/linuxserver/baseimage-rdesktop-web:arm64v8-jammy
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-rdesktop-web:arm32v7-focal
+FROM ghcr.io/linuxserver/baseimage-rdesktop-web:arm32v7-jammy
 
 # set version label
 ARG BUILD_DATE


### PR DESCRIPTION
As is, the focal version of Ubuntu KDE only runs in priv mode and many apps have problems. 
I want to pull priv mode out of the readme as seccomp unconfined seems to fix all app issues (vscode etc).
Getting this functional is a prerequisite. 