### PR TITLE
Install Firefox from PPA instead of stub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,12 @@ ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="thelamer"
 
+# prevent Ubuntu's firefox stub from being installed
+COPY /root/etc/apt/preferences.d/firefox-no-snap /etc/apt/preferences.d/firefox-no-snap
+
 RUN \
   echo "**** install packages ****" && \
+  add-apt-repository -y ppa:mozillateam/ppa && \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive \
   apt-get install --no-install-recommends -y \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -6,8 +6,12 @@ ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="thelamer"
 
+# prevent Ubuntu's firefox stub from being installed
+COPY /root/etc/apt/preferences.d/firefox-no-snap /etc/apt/preferences.d/firefox-no-snap
+
 RUN \
   echo "**** install packages ****" && \
+  add-apt-repository -y ppa:mozillateam/ppa && \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive \
   apt-get install --no-install-recommends -y \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -6,8 +6,12 @@ ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="thelamer"
 
+# prevent Ubuntu's firefox stub from being installed
+COPY /root/etc/apt/preferences.d/firefox-no-snap /etc/apt/preferences.d/firefox-no-snap
+
 RUN \
   echo "**** install packages ****" && \
+  add-apt-repository -y ppa:mozillateam/ppa && \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive \
   apt-get install --no-install-recommends -y \

--- a/root/etc/apt/preferences.d/firefox-no-snap
+++ b/root/etc/apt/preferences.d/firefox-no-snap
@@ -1,0 +1,3 @@
+Package: firefox*
+Pin: release o=Ubuntu*
+Pin-Priority: -1


### PR DESCRIPTION
On Ubuntu 22.04 (`jammy`), installing the `firefox` package via apt installs a stub that tells you to use the snap instead, which isn't possible in a docker container. To get around this, Mozilla's PPA is added in the Dockerfile and the stub is pinned to prevent it from being installed.