### PR TITLE
remove power manager plugin as it delays init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN \
   apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
     xfce4-pulseaudio-plugin && \
   echo "**** cleanup ****" && \
+  rm -f /usr/share/xfce4/panel/plugins/power-manager-plugin.desktop && \
   rm -rf \
     /tmp/*
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -22,6 +22,7 @@ RUN \
   apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
     xfce4-pulseaudio-plugin && \
   echo "**** cleanup ****" && \
+  rm -f /usr/share/xfce4/panel/plugins/power-manager-plugin.desktop && \
   rm -rf \
     /tmp/*
 

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -22,6 +22,7 @@ RUN \
   apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
     xfce4-pulseaudio-plugin && \
   echo "**** cleanup ****" && \
+  rm -f /usr/share/xfce4/panel/plugins/power-manager-plugin.desktop && \
   rm -rf \
     /tmp/*
 


### PR DESCRIPTION
This pulls out the power manager plugin as it is not needed and it actually causes a significant delay on init if the underlying hardware does not support it. 