### PR TITLE
rebase alpine-icewm to 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-kasmvnc:alpine317
+FROM ghcr.io/linuxserver/baseimage-kasmvnc:alpine318
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-kasmvnc:arm64v8-alpine317
+FROM ghcr.io/linuxserver/baseimage-kasmvnc:arm64v8-alpine318
 
 # set version label
 ARG BUILD_DATE


### PR DESCRIPTION
Part of a larger rebase effort  for all alpine based desktop containers. 