### PR TITLE
rebase fedora-icewm to 38

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-kasmvnc:fedora37
+FROM ghcr.io/linuxserver/baseimage-kasmvnc:fedora38
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-kasmvnc:arm64v8-fedora37
+FROM ghcr.io/linuxserver/baseimage-kasmvnc:arm64v8-fedora38
 
 # set version label
 ARG BUILD_DATE


### PR DESCRIPTION
Part of a larger rebase effort  for all fedora based desktop containers. 