### PR TITLE
rebase fedora-openbox to 39

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-kasmvnc:fedora38
+FROM ghcr.io/linuxserver/baseimage-kasmvnc:fedora39
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-kasmvnc:arm64v8-fedora38
+FROM ghcr.io/linuxserver/baseimage-kasmvnc:arm64v8-fedora39
 
 # set version label
 ARG BUILD_DATE


### PR DESCRIPTION
Rebases to fedora 39, not many changes and low impact 6 month update.
The new startup messages from X can be ignored those are just warnings and will be expected in head versions of X from here out. 