### PR TITLE
docs on proot-apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,15 @@ The Webtop can be accessed at:
 
 **Modern GUI desktop apps (including some flavors terminals) have issues with the latest Docker and syscall compatibility, you can use Docker with the `--security-opt seccomp=unconfined` setting to allow these syscalls**
 
-**Unlike our other containers these Desktops are not designed to be upgraded by Docker, you will keep your home directory but anything you installed system level will be lost if you upgrade an existing container. To keep packages up to date instead use Ubuntu/Debians's own apt, Alpine's apk, Fedora's dnf, or Arch's pacman program**
+### Application management - PRoot Apps
+
+If you run system native installations of software IE `sudo apt-get install filezilla` and then upgrade or destroy/re-create the container that software will be removed and the Webtop will be at a clean state. For some users that will be acceptable and they can update their system packages as well using system native commands like `apt-get upgrade`. If you want Docker to handle upgrading the container and retain your applications and settings we have created [proot-apps](https://github.com/linuxserver/proot-apps) which allow portable applications to be installed to persistent storage in the user's `$HOME` directory and they will work in a confined Docker environment out of the box. These applications and their settings will persist upgrades of the base container and can be mounted into different flavors of Webtop containers on the fly facilitating virtual "Distro Hopping". IE if you are running the `alpine-mate` Webtop you will be able to use the same `/config` directory mounted into the `arch-kde` Webtop and retain the same applications and settings as long as they were installed with `proot-apps install`. This can be achieved from the command line with:
+
+```
+proot-apps install filezilla
+```
+
+PRoot Apps is included in all KasmVNC based containers, a list of linuxserver.io supported applications is located [HERE](https://github.com/linuxserver/proot-apps?tab=readme-ov-file#supported-apps).
 
 ### Options in all KasmVNC based GUI containers
 
@@ -386,6 +394,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **16.04.24:** - Add docs on PRoot Apps.
 * **14.04.24:** - Rebase Fedora to 40.
 * **11.02.24:** - Add PWA icons and title variants properly.
 * **06.02.24:** - Update Readme about native language support.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -86,7 +86,15 @@ app_setup_block: |
 
   **Modern GUI desktop apps (including some flavors terminals) have issues with the latest Docker and syscall compatibility, you can use Docker with the `--security-opt seccomp=unconfined` setting to allow these syscalls**
 
-  **Unlike our other containers these Desktops are not designed to be upgraded by Docker, you will keep your home directory but anything you installed system level will be lost if you upgrade an existing container. To keep packages up to date instead use Ubuntu/Debians's own apt, Alpine's apk, Fedora's dnf, or Arch's pacman program**
+  ### Application management - PRoot Apps
+
+  If you run system native installations of software IE `sudo apt-get install filezilla` and then upgrade or destroy/re-create the container that software will be removed and the Webtop will be at a clean state. For some users that will be acceptable and they can update their system packages as well using system native commands like `apt-get upgrade`. If you want Docker to handle upgrading the container and retain your applications and settings we have created [proot-apps](https://github.com/linuxserver/proot-apps) which allow portable applications to be installed to persistent storage in the user's `$HOME` directory and they will work in a confined Docker environment out of the box. These applications and their settings will persist upgrades of the base container and can be mounted into different flavors of Webtop containers on the fly facilitating virtual "Distro Hopping". IE if you are running the `alpine-mate` Webtop you will be able to use the same `/config` directory mounted into the `arch-kde` Webtop and retain the same applications and settings as long as they were installed with `proot-apps install`. This can be achieved from the command line with:
+
+  ```
+  proot-apps install filezilla
+  ```
+
+  PRoot Apps is included in all KasmVNC based containers, a list of linuxserver.io supported applications is located [HERE](https://github.com/linuxserver/proot-apps?tab=readme-ov-file#supported-apps).
 
   ### Options in all KasmVNC based GUI containers
 
@@ -138,6 +146,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "16.04.24:", desc: "Add docs on PRoot Apps." }
   - { date: "14.04.24:", desc: "Rebase Fedora to 40." }
   - { date: "11.02.24:", desc: "Add PWA icons and title variants properly." }
   - { date: "06.02.24:", desc: "Update Readme about native language support." }


### PR DESCRIPTION
Adding docs on proot-apps now in the baseimage, expands the software upgrade warning. 