### PR TITLE
document initial nvidia support

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,60 @@ To install cjk fonts on startup as an example pass the environment variables (Al
 
 The web interface has the option for "IME Input Mode" in Settings which will allow non english characters to be used from a non en_US keyboard on the client. Once enabled it will perform the same as a local Linux installation set to your locale.
 
+### DRI3 GPU Acceleration
+
+For accelerated apps or games, render devices can be mounted into the container and leveraged by applications using:
+
+`--device /dev/dri:/dev/dri`
+
+This feature only supports **Open Source** GPU drivers:
+
+| Driver | Description |
+| :----: | --- |
+| Intel | i965 and i915 drivers for Intel iGPU chipsets |
+| AMD | AMDGPU, Radeon, and ATI drivers for AMD dedicated or APU chipsets |
+| NVIDIA | nouveau2 drivers only, closed source NVIDIA drivers lack DRI3 support |
+
+The `DRINODE` environment variable can be used to point to a specific GPU.
+Up to date information can be found [here](https://www.kasmweb.com/kasmvnc/docs/master/gpu_acceleration.html)
+
+#### Display Compositing (desktop effects)
+
+When using this image in tandem with a supported video card, compositing will function albeit with a performance hit when syncing the frames with pixmaps for the applications using it. This can greatly increase app compatibility if the application in question requires compositing, but requires a real GPU to be mounted into the container. By default we disable compositing at a DE level for performance reasons on our downstream images, but it can be enabled by the user and programs using compositing will still function even if the DE has it disabled in its settings. When building desktop images be sure you understand that with it enabled by default only users that have a compatible GPU mounted in will be able to use your image.
+
+### Nvidia GPU Support
+
+**Nvidia is not compatible with Alpine based images**
+
+Nvidia support is available by leveraging Zink for OpenGL support. This can be enabled with the following run flags:
+
+| Variable | Description |
+| :----: | --- |
+| --gpus all | This can be filtered down but for most setups this will pass the one Nvidia GPU on the system |
+| --runtime nvidia | Specify the Nvidia runtime which mounts drivers and tools in from the host |
+
+The compose syntax is slightly different for this as you will need to set nvidia as the default runtime:
+
+```
+sudo nvidia-ctk runtime configure --runtime=docker --set-as-default
+sudo service docker restart
+```
+
+And to assign the GPU in compose:
+
+```
+services:
+  webtop:
+    image: linuxserver/webtop:debian-kde
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [compute,video,graphics,utility]
+```
+
 ### Lossless mode
 
 This container is capable of delivering a true lossless image at a high framerate to your web browser by changing the Stream Quality preset to "Lossless", more information [here](https://www.kasmweb.com/docs/latest/how_to/lossless.html#technical-background). In order to use this mode from a non localhost endpoint the HTTPS port on 3001 needs to be used. If using a reverse proxy to port 3000 specific headers will need to be set as outlined [here](https://github.com/linuxserver/docker-baseimage-kasmvnc#lossless).
@@ -394,7 +448,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
-* **23.05.24:** - Rebase Alpine to 3.20.
+* **23.05.24:** - Rebase Alpine to 3.20, document Nvidia support.
 * **22.04.24:** - Rebase Ubuntu to Noble.
 * **16.04.24:** - Add docs on PRoot Apps.
 * **14.04.24:** - Rebase Fedora to 40.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -140,13 +140,67 @@ app_setup_block: |
 
   The web interface has the option for "IME Input Mode" in Settings which will allow non english characters to be used from a non en_US keyboard on the client. Once enabled it will perform the same as a local Linux installation set to your locale.
 
+  ### DRI3 GPU Acceleration
+
+  For accelerated apps or games, render devices can be mounted into the container and leveraged by applications using:
+
+  `--device /dev/dri:/dev/dri`
+
+  This feature only supports **Open Source** GPU drivers:
+
+  | Driver | Description |
+  | :----: | --- |
+  | Intel | i965 and i915 drivers for Intel iGPU chipsets |
+  | AMD | AMDGPU, Radeon, and ATI drivers for AMD dedicated or APU chipsets |
+  | NVIDIA | nouveau2 drivers only, closed source NVIDIA drivers lack DRI3 support |
+
+  The `DRINODE` environment variable can be used to point to a specific GPU.
+  Up to date information can be found [here](https://www.kasmweb.com/kasmvnc/docs/master/gpu_acceleration.html)
+
+  #### Display Compositing (desktop effects)
+
+  When using this image in tandem with a supported video card, compositing will function albeit with a performance hit when syncing the frames with pixmaps for the applications using it. This can greatly increase app compatibility if the application in question requires compositing, but requires a real GPU to be mounted into the container. By default we disable compositing at a DE level for performance reasons on our downstream images, but it can be enabled by the user and programs using compositing will still function even if the DE has it disabled in its settings. When building desktop images be sure you understand that with it enabled by default only users that have a compatible GPU mounted in will be able to use your image.
+
+  ### Nvidia GPU Support
+
+  **Nvidia is not compatible with Alpine based images**
+
+  Nvidia support is available by leveraging Zink for OpenGL support. This can be enabled with the following run flags:
+
+  | Variable | Description |
+  | :----: | --- |
+  | --gpus all | This can be filtered down but for most setups this will pass the one Nvidia GPU on the system |
+  | --runtime nvidia | Specify the Nvidia runtime which mounts drivers and tools in from the host |
+
+  The compose syntax is slightly different for this as you will need to set nvidia as the default runtime:
+
+  ```
+  sudo nvidia-ctk runtime configure --runtime=docker --set-as-default
+  sudo service docker restart
+  ```
+
+  And to assign the GPU in compose:
+
+  ```
+  services:
+    webtop:
+      image: linuxserver/webtop:debian-kde
+      deploy:
+        resources:
+          reservations:
+            devices:
+              - driver: nvidia
+                count: 1
+                capabilities: [compute,video,graphics,utility]
+  ```
+
   ### Lossless mode
 
   This container is capable of delivering a true lossless image at a high framerate to your web browser by changing the Stream Quality preset to "Lossless", more information [here](https://www.kasmweb.com/docs/latest/how_to/lossless.html#technical-background). In order to use this mode from a non localhost endpoint the HTTPS port on 3001 needs to be used. If using a reverse proxy to port 3000 specific headers will need to be set as outlined [here](https://github.com/linuxserver/docker-baseimage-kasmvnc#lossless).
 
 # changelog
 changelogs:
-  - { date: "23.05.24:", desc: "Rebase Alpine to 3.20." }
+  - { date: "23.05.24:", desc: "Rebase Alpine to 3.20, document Nvidia support." }
   - { date: "22.04.24:", desc: "Rebase Ubuntu to Noble." }
   - { date: "16.04.24:", desc: "Add docs on PRoot Apps." }
   - { date: "14.04.24:", desc: "Rebase Fedora to 40." }


### PR DESCRIPTION
Add docs for the initial Nvidia support leveraging Zink.

All the Glibc images have logic to export Zink env vars if they detect the nvidia runtime, they also no longer try to use the Nvidia GPU for DRI3. 