### PR TITLE
Fix: Remove default --no-sandbox flag from Chromium configuration (#284)

### DIFF
--- a/root/usr/bin/chromium
+++ b/root/usr/bin/chromium
@@ -11,5 +11,5 @@ fi
 if grep -q 'Seccomp:.0' /proc/1/status; then
   ${BIN} --no-first-run --password-store=basic "$@"
 else
-  ${BIN} --no-first-run --password-store=basic --no-sandbox --test-type "$@"
+  ${BIN} --no-first-run --password-store=basic "$@"
 fi


### PR DESCRIPTION
- Investigated and resolved Issue #284.
- Ensured Chromium browser runs securely without automatically adding the --no-sandbox flag.
- Updated configurations to allow manual flag addition if necessary.
- Tested functionality in the Docker environment to ensure compatibility and stability.