### PR TITLE
trixie kde rebase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-selkies:debianbookworm
+FROM ghcr.io/linuxserver/baseimage-selkies:debiantrixie
 
 # set version label
 ARG BUILD_DATE
@@ -26,7 +26,6 @@ RUN \
     kde-config-gtk-style \
     kdialog \
     kfind \
-    khotkeys \
     kio-extras \
     knewstuff-dialog \
     konsole \
@@ -37,7 +36,8 @@ RUN \
     plasma-desktop \
     plasma-workspace \
     qml-module-qt-labs-platform \
-    systemsettings && \
+    systemsettings \
+    xserver-xorg-input-libinput && \
   echo "**** application tweaks ****" && \
   sed -i \
     's#^Exec=.*#Exec=/usr/local/bin/wrapped-chromium#g' \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-selkies:arm64v8-debianbookworm
+FROM ghcr.io/linuxserver/baseimage-selkies:arm64v8-debiantrixie
 
 # set version label
 ARG BUILD_DATE
@@ -26,7 +26,6 @@ RUN \
     kde-config-gtk-style \
     kdialog \
     kfind \
-    khotkeys \
     kio-extras \
     knewstuff-dialog \
     konsole \
@@ -37,7 +36,8 @@ RUN \
     plasma-desktop \
     plasma-workspace \
     qml-module-qt-labs-platform \
-    systemsettings && \
+    systemsettings \
+    xserver-xorg-input-libinput && \
   echo "**** application tweaks ****" && \
   sed -i \
     's#^Exec=.*#Exec=/usr/local/bin/wrapped-chromium#g' \

--- a/root/defaults/startwm.sh
+++ b/root/defaults/startwm.sh
@@ -2,10 +2,10 @@
 
 # Disable compositing and screen locking
 if [ ! -f $HOME/.config/kwinrc ]; then
-  kwriteconfig5 --file $HOME/.config/kwinrc --group Compositing --key Enabled false
+  kwriteconfig6 --file $HOME/.config/kwinrc --group Compositing --key Enabled false
 fi
 if [ ! -f $HOME/.config/kscreenlockerrc ]; then
-  kwriteconfig5 --file $HOME/.config/kscreenlockerrc --group Daemon --key Autolock false
+  kwriteconfig6 --file $HOME/.config/kscreenlockerrc --group Daemon --key Autolock false
 fi
 
 # Power related


### PR DESCRIPTION
Feature freeze is in 5 days and most of what trixie is pushing is basically head so I do not see them changing much between now and the 9th. 

No bugs found and unlike Arch this still seems to work on older kernel hosts. There is a load issue when in pure CPU mode but that just comes with the territory of using KDE6, it can never truly turn off all compositing and stuff like dragging a window around quickly will make kwin_x11 CPU burn with llvmpipe more than KDE 5. 