### PR TITLE
rebase to 3.24 mate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-selkies:alpine323
+FROM ghcr.io/linuxserver/baseimage-selkies:alpine324
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-selkies:arm64v8-alpine323
+FROM ghcr.io/linuxserver/baseimage-selkies:arm64v8-alpine324
 
 # set version label
 ARG BUILD_DATE


### PR DESCRIPTION
Alpine 3.24 rebases, this fixes the icons from the 3.23 builds, still no wayland support. 